### PR TITLE
Remove vim configurations from source code.

### DIFF
--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -669,4 +669,4 @@ k_msgq msgq, msgq_control;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/actuator_controller.hpp
+++ b/lexxpluss_apps/src/actuator_controller.hpp
@@ -53,4 +53,4 @@ extern k_msgq msgq, msgq_control;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/adc_reader.cpp
+++ b/lexxpluss_apps/src/adc_reader.cpp
@@ -100,4 +100,4 @@ k_thread thread;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/adc_reader.hpp
+++ b/lexxpluss_apps/src/adc_reader.hpp
@@ -46,4 +46,4 @@ enum {
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -438,4 +438,4 @@ k_msgq msgq_bmu, msgq_board, msgq_control;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -70,4 +70,4 @@ extern k_msgq msgq_bmu, msgq_board, msgq_control;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/imu_controller.cpp
+++ b/lexxpluss_apps/src/imu_controller.cpp
@@ -131,4 +131,4 @@ k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/imu_controller.hpp
+++ b/lexxpluss_apps/src/imu_controller.hpp
@@ -44,5 +44,5 @@ extern k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+
 

--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -369,4 +369,4 @@ k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/led_controller.hpp
+++ b/lexxpluss_apps/src/led_controller.hpp
@@ -81,4 +81,4 @@ extern k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/log_controller.cpp
+++ b/lexxpluss_apps/src/log_controller.cpp
@@ -124,4 +124,4 @@ SHELL_CMD_REGISTER(mlog, &sub, "Memory log commands", NULL);
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -106,4 +106,4 @@ void main()
     }
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/misc_controller.cpp
+++ b/lexxpluss_apps/src/misc_controller.cpp
@@ -120,4 +120,4 @@ k_thread thread;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/misc_controller.hpp
+++ b/lexxpluss_apps/src/misc_controller.hpp
@@ -37,4 +37,4 @@ extern k_thread thread;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/pgv_controller.cpp
+++ b/lexxpluss_apps/src/pgv_controller.cpp
@@ -296,4 +296,4 @@ k_msgq msgq, msgq_control;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/pgv_controller.hpp
+++ b/lexxpluss_apps/src/pgv_controller.hpp
@@ -51,4 +51,4 @@ extern k_msgq msgq, msgq_control;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial.cpp
+++ b/lexxpluss_apps/src/rosserial.cpp
@@ -91,4 +91,4 @@ k_thread thread;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial.hpp
+++ b/lexxpluss_apps/src/rosserial.hpp
@@ -35,4 +35,4 @@ extern k_thread thread;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_actuator.hpp
+++ b/lexxpluss_apps/src/rosserial_actuator.hpp
@@ -82,4 +82,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_actuator_service.hpp
+++ b/lexxpluss_apps/src/rosserial_actuator_service.hpp
@@ -70,4 +70,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_bmu.hpp
+++ b/lexxpluss_apps/src/rosserial_bmu.hpp
@@ -99,4 +99,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_board.hpp
+++ b/lexxpluss_apps/src/rosserial_board.hpp
@@ -147,4 +147,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_hardware_zephyr.hpp
+++ b/lexxpluss_apps/src/rosserial_hardware_zephyr.hpp
@@ -111,4 +111,4 @@ typedef NodeHandle_<rosserial_hardware_zephyr> NodeHandle;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_imu.hpp
+++ b/lexxpluss_apps/src/rosserial_imu.hpp
@@ -62,4 +62,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_led.hpp
+++ b/lexxpluss_apps/src/rosserial_led.hpp
@@ -62,4 +62,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_pgv.hpp
+++ b/lexxpluss_apps/src/rosserial_pgv.hpp
@@ -98,4 +98,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_service.cpp
+++ b/lexxpluss_apps/src/rosserial_service.cpp
@@ -61,4 +61,4 @@ k_thread thread;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_service.hpp
+++ b/lexxpluss_apps/src/rosserial_service.hpp
@@ -35,4 +35,4 @@ extern k_thread thread;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_tof.hpp
+++ b/lexxpluss_apps/src/rosserial_tof.hpp
@@ -56,4 +56,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/rosserial_uss.hpp
+++ b/lexxpluss_apps/src/rosserial_uss.hpp
@@ -58,4 +58,4 @@ private:
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/sdlog_controller.cpp
+++ b/lexxpluss_apps/src/sdlog_controller.cpp
@@ -251,4 +251,4 @@ k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/sdlog_controller.hpp
+++ b/lexxpluss_apps/src/sdlog_controller.hpp
@@ -44,4 +44,4 @@ extern k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/tof_controller.cpp
+++ b/lexxpluss_apps/src/tof_controller.cpp
@@ -71,4 +71,4 @@ k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/tof_controller.hpp
+++ b/lexxpluss_apps/src/tof_controller.hpp
@@ -40,4 +40,4 @@ extern k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/uss_controller.cpp
+++ b/lexxpluss_apps/src/uss_controller.cpp
@@ -150,4 +150,4 @@ k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+

--- a/lexxpluss_apps/src/uss_controller.hpp
+++ b/lexxpluss_apps/src/uss_controller.hpp
@@ -41,4 +41,4 @@ extern k_msgq msgq;
 
 }
 
-// vim: set expandtab shiftwidth=4:
+


### PR DESCRIPTION
Source and header files contains commented vim configurations.
Is there a reason why these configurations are directly in source code and not in a local vim configuration file?
