### PR TITLE
Amrsw 235 add pub topic

### DIFF
--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -382,7 +382,7 @@ private:
     const device *dev{nullptr};
     char version_powerboard[32]{""};
     bool heartbeat_timeout{true}, enable_lockdown{true};
-    static constexpr char version[]{"2.6.0"};
+    static constexpr char version[]{"2.6.1"};
 } impl;
 
 int bmu_info(const shell *shell, size_t argc, char **argv)

--- a/lexxpluss_apps/src/rosserial_board.hpp
+++ b/lexxpluss_apps/src/rosserial_board.hpp
@@ -32,6 +32,7 @@
 #include "std_msgs/ByteMultiArray.h"
 #include "std_msgs/String.h"
 #include "std_msgs/UInt8MultiArray.h"
+#include "std_msgs/UInt8.h"
 #include "lexxauto_msgs/BoardTemperatures.h"
 #include "can_controller.hpp"
 
@@ -46,6 +47,7 @@ public:
         nh.advertise(pub_charge);
         nh.advertise(pub_temperature);
         nh.advertise(pub_power);
+        nh.advertise(pub_charge_delay);
         nh.subscribe(sub_emergency);
         nh.subscribe(sub_poweroff);
         nh.subscribe(sub_lexxhard);
@@ -63,6 +65,7 @@ public:
             publish_charge(message);
             publish_temperature(message);
             publish_power(message);
+            publish_charge_delay(message);
         }
     }
 private:
@@ -104,6 +107,10 @@ private:
         msg_power.data = message.wait_shutdown ? message.shutdown_reason : 0;
         pub_power.publish(&msg_power);
     }
+    void publish_charge_delay(const can_controller::msg_board &message) {
+        msg_charge_delay.data = message.charge_heartbeat_delay;
+        pub_charge_delay.publish(&msg_charge_delay);
+    }
     void callback_emergency(const std_msgs::Bool &req) {
         ros2board.emergency_stop = req.data;
         while (k_msgq_put(&can_controller::msgq_control, &ros2board, K_NO_WAIT) != 0)
@@ -125,6 +132,7 @@ private:
     std_msgs::Bool msg_emergency;
     std_msgs::Byte msg_charge, msg_power;
     lexxauto_msgs::BoardTemperatures msg_temperature;
+    std_msgs::UInt8 msg_charge_delay;
     can_controller::msg_control ros2board{0};
     uint8_t msg_fan_data[1];
     int8_t msg_bumper_data[2];
@@ -134,6 +142,7 @@ private:
     ros::Publisher pub_charge{"/body_control/charge_status", &msg_charge};
     ros::Publisher pub_temperature{"/sensor_set/temperature", &msg_temperature};
     ros::Publisher pub_power{"/body_control/power_state", &msg_power};
+    ros::Publisher pub_charge_delay{"/body_control/charge_heartbeat_delay", &msg_charge_delay};
     ros::Subscriber<std_msgs::Bool, ros_board> sub_emergency{
         "/control/request_emergency_stop", &ros_board::callback_emergency, this
     };

--- a/lexxpluss_apps/src/rosserial_board.hpp
+++ b/lexxpluss_apps/src/rosserial_board.hpp
@@ -33,6 +33,7 @@
 #include "std_msgs/String.h"
 #include "std_msgs/UInt8MultiArray.h"
 #include "std_msgs/UInt8.h"
+#include "std_msgs/Float32.h"
 #include "lexxauto_msgs/BoardTemperatures.h"
 #include "can_controller.hpp"
 
@@ -48,6 +49,7 @@ public:
         nh.advertise(pub_temperature);
         nh.advertise(pub_power);
         nh.advertise(pub_charge_delay);
+        nh.advertise(pub_charge_voltage);
         nh.subscribe(sub_emergency);
         nh.subscribe(sub_poweroff);
         nh.subscribe(sub_lexxhard);
@@ -66,6 +68,7 @@ public:
             publish_temperature(message);
             publish_power(message);
             publish_charge_delay(message);
+            publish_charge_voltage(message);
         }
     }
 private:
@@ -111,6 +114,10 @@ private:
         msg_charge_delay.data = message.charge_heartbeat_delay;
         pub_charge_delay.publish(&msg_charge_delay);
     }
+    void publish_charge_voltage(const can_controller::msg_board &message) {
+        msg_charge_voltage.data = message.charge_connector_voltage;
+        pub_charge_voltage.publish(&msg_charge_voltage);
+    }
     void callback_emergency(const std_msgs::Bool &req) {
         ros2board.emergency_stop = req.data;
         while (k_msgq_put(&can_controller::msgq_control, &ros2board, K_NO_WAIT) != 0)
@@ -133,6 +140,7 @@ private:
     std_msgs::Byte msg_charge, msg_power;
     lexxauto_msgs::BoardTemperatures msg_temperature;
     std_msgs::UInt8 msg_charge_delay;
+    std_msgs::Float32 msg_charge_voltage;
     can_controller::msg_control ros2board{0};
     uint8_t msg_fan_data[1];
     int8_t msg_bumper_data[2];
@@ -143,6 +151,7 @@ private:
     ros::Publisher pub_temperature{"/sensor_set/temperature", &msg_temperature};
     ros::Publisher pub_power{"/body_control/power_state", &msg_power};
     ros::Publisher pub_charge_delay{"/body_control/charge_heartbeat_delay", &msg_charge_delay};
+    ros::Publisher pub_charge_voltage{"/body_control/charge_connector_voltage", &msg_charge_voltage};
     ros::Subscriber<std_msgs::Bool, ros_board> sub_emergency{
         "/control/request_emergency_stop", &ros_board::callback_emergency, this
     };


### PR DESCRIPTION
Close AMRSW-235

充電失敗の調査の為、mainboard側から出力するトピックを追加する。

LexxAuto側では該当のtopicをrosbagに保存し、充電失敗の際のsequenceを解析予定。
充電失敗の原因を検出する為に以下のトピックを保存する。

/body_control/charge_status
/body_control/charge_heartbeat_delay
/body_control/charge_connector_voltage

IrDAが通信出来ている間は、charge_heartbeat_delay が 0 のまま推移する為、
charge_status が AUTO_CHARGE_STATE のまま heartbeat_delay が上昇した場合、IrDAが途絶していて
charge_status が AUTO_CHARGE_STATE のまま connector_voltageが減少した場合、充電端子が離れたと言えると考える。