### PR TITLE
[AMRSW-621] add callback for mainboard_messenger topic

### DIFF
--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -382,7 +382,7 @@ private:
     const device *dev{nullptr};
     char version_powerboard[32]{""};
     bool heartbeat_timeout{true}, enable_lockdown{true};
-    static constexpr char version[]{"2.7.0"};
+    static constexpr char version[]{"2.7.1"};
 } impl;
 
 int bmu_info(const shell *shell, size_t argc, char **argv)

--- a/lexxpluss_apps/src/rosserial_board.hpp
+++ b/lexxpluss_apps/src/rosserial_board.hpp
@@ -53,6 +53,7 @@ public:
         nh.subscribe(sub_emergency);
         nh.subscribe(sub_poweroff);
         nh.subscribe(sub_lexxhard);
+        nh.subscribe(sub_messenger);
         msg_fan.data = msg_fan_data;
         msg_fan.data_length = sizeof msg_fan_data / sizeof msg_fan_data[0];
         msg_bumper.data = msg_bumper_data;
@@ -134,6 +135,10 @@ private:
         while (k_msgq_put(&can_controller::msgq_control, &ros2board, K_NO_WAIT) != 0)
             k_msgq_purge(&can_controller::msgq_control);
     }
+    void callback_messenger(const std_msgs::Bool &req) {
+        while (k_msgq_put(&can_controller::msgq_control, &ros2board, K_NO_WAIT) != 0)
+            k_msgq_purge(&can_controller::msgq_control);
+    }
     std_msgs::UInt8MultiArray msg_fan;
     std_msgs::ByteMultiArray msg_bumper;
     std_msgs::Bool msg_emergency;
@@ -160,6 +165,9 @@ private:
     };
     ros::Subscriber<std_msgs::String, ros_board> sub_lexxhard{
         "/lexxhard/setup", &ros_board::callback_lexxhard, this
+    };
+    ros::Subscriber<std_msgs::Bool, ros_board> sub_messenger{
+        "/lexxhard/mainboard_messenger_heartbeat", &ros_board::callback_messenger, this
     };
 };
 


### PR DESCRIPTION
Closes [AMRSW-758](https://lexxpluss.atlassian.net/browse/AMRSW-758)
Subscribe to `mainboard_messenger_heartbeat` rostopic to stop lockdown from happening when noetic_auto_launch container is restarted.

[AMRSW-758]: https://lexxpluss.atlassian.net/browse/AMRSW-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ