### PR TITLE
HWDEV-2101 update version

### DIFF
--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -380,7 +380,7 @@ private:
     
     // Version Definition
     // [Hardware Change].[function added or interface change].[bug fix, reset to 0 when the compatibility is lost]
-    static constexpr char version[]{"2.8.0"}; 
+    static constexpr char version[]{"2.9.0"};
 } impl;
 
 int bmu_info(const shell *shell, size_t argc, char **argv)


### PR DESCRIPTION
Ref: [HWDEV-2101](https://lexxpluss.atlassian.net/browse/HWDEV-2101)

This PR is motivated to update version to v2.9.0

[HWDEV-2101]: https://lexxpluss.atlassian.net/browse/HWDEV-2101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ