### PR TITLE
HWDEV-2110 disable lockdown when emergency switch is asserted

### DIFF
--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -361,7 +361,7 @@ private:
             .data{
                 ros2board.emergency_stop,
                 ros2board.power_off,
-                heartbeat_timeout,
+                !get_emergency_switch() && heartbeat_timeout,
                 main_overheat,
                 actuator_overheat,
                 ros2board.wheel_power_off


### PR DESCRIPTION
Ref [HWDEV-2110](https://lexxpluss.atlassian.net/browse/HWDEV-2110)

This PR is motivated to disable lockdown when emergency switch is asserted.

[HWDEV-2110]: https://lexxpluss.atlassian.net/browse/HWDEV-2110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ