### PR TITLE
HWDEV-2127 add emergency_stop topic

### DIFF
--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -353,6 +353,8 @@ private:
             board2ros.charge_heartbeat_delay = frame.data[3];
             board2ros.charge_temperature_error = frame.data[4];
         }
+
+        board2ros.emergency_stop = is_emergency();
     }
     void handler_log(zcan_frame &frame) {
         for (uint32_t i{0}; i < frame.dlc; ++i) {

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -55,6 +55,7 @@ struct msg_board {
     bool c_fet, d_fet, p_dsg, v5_fail, v16_fail;
     bool wheel_disable[2];
     bool charge_temperature_error;
+    bool emergency_stop;
 } __attribute__((aligned(4)));
 
 struct msg_control {

--- a/lexxpluss_apps/src/rosserial_board.hpp
+++ b/lexxpluss_apps/src/rosserial_board.hpp
@@ -70,6 +70,7 @@ public:
             publish_power(message);
             publish_charge_delay(message);
             publish_charge_voltage(message);
+            publish_emergency_stop(message);
         }
     }
 private:
@@ -119,6 +120,10 @@ private:
         msg_charge_voltage.data = message.charge_connector_voltage;
         pub_charge_voltage.publish(&msg_charge_voltage);
     }
+    void publish_emergency_stop(const can_controller::msg_board &message) {
+        msg_emergency_stop.data = message.emergency_stop;
+        pub_emergency_stop.publish(&msg_emergency_stop);
+    }
     void callback_emergency(const std_msgs::Bool &req) {
         ros2board.emergency_stop = req.data;
         while (k_msgq_put(&can_controller::msgq_control, &ros2board, K_NO_WAIT) != 0)
@@ -146,6 +151,7 @@ private:
     lexxauto_msgs::BoardTemperatures msg_temperature;
     std_msgs::UInt8 msg_charge_delay;
     std_msgs::Float32 msg_charge_voltage;
+    std_msgs::Bool msg_emergency_stop;
     can_controller::msg_control ros2board{0};
     uint8_t msg_fan_data[1];
     int8_t msg_bumper_data[2];
@@ -157,6 +163,7 @@ private:
     ros::Publisher pub_power{"/body_control/power_state", &msg_power};
     ros::Publisher pub_charge_delay{"/body_control/charge_heartbeat_delay", &msg_charge_delay};
     ros::Publisher pub_charge_voltage{"/body_control/charge_connector_voltage", &msg_charge_voltage};
+    ros::Publisher pub_emergency_stop{"/body_control/emergency_stop", &msg_emergency_stop};
     ros::Subscriber<std_msgs::Bool, ros_board> sub_emergency{
         "/control/request_emergency_stop", &ros_board::callback_emergency, this
     };

--- a/lexxpluss_apps/src/rosserial_board.hpp
+++ b/lexxpluss_apps/src/rosserial_board.hpp
@@ -50,6 +50,7 @@ public:
         nh.advertise(pub_power);
         nh.advertise(pub_charge_delay);
         nh.advertise(pub_charge_voltage);
+        nh.advertise(pub_emergency_stop);
         nh.subscribe(sub_emergency);
         nh.subscribe(sub_poweroff);
         nh.subscribe(sub_lexxhard);


### PR DESCRIPTION
ref: [HWDEV-2127](https://lexxpluss.atlassian.net/browse/HWDEV-2127)

This PR is motivated to add a topic whose name is `/body_control/emergency_stop` to publish whether robot is in emergency stop or not.

The results of this PR are followings.

**not emergency stop**
```
lexxauto@v63mp007:~/LexxAuto$ rostopic echo /body_control/emergency_stop
data: False
---
data: False
---
data: False
```

**emergency stop by e-switch**
```
lexxauto@v63mp007:~/LexxAuto$ rostopic echo /body_control/emergency_stop
data: True
---
data: True
---
data: True
```

**emergency stop by bumper**
```
lexxauto@v63mp007:~/LexxAuto$ rostopic echo /body_control/emergency_stop
data: True
---
data: True
---
data: True
```

[HWDEV-2127]: https://lexxpluss.atlassian.net/browse/HWDEV-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ