### PR TITLE
HWDEV-2022 add tug edition

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/zephyr-build:v0.21.0
+      options: --user root
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,10 @@ jobs:
         id: build
         run: |
           set -e
-          make IN_HOST=1 setup
-          make IN_HOST=1 bootloader
-          make IN_HOST=1 firmware
+          cp -a /home/user/.cmake $HOME
+          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb make IN_HOST=1 setup
+          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb make IN_HOST=1 bootloader
+          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb make IN_HOST=1 firmware
       - name: Notification
         uses: act10ns/slack@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/zephyr-build:v0.21.0
-      options: --user root
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -43,12 +42,9 @@ jobs:
         id: build
         run: |
           set -e
-          west init -l lexxpluss_apps
-          west update
-          west config --global zephyr.base-prefer configfile
-          west zephyr-export
-          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb west build -b lexxpluss_mb02 bootloader/mcuboot/boot/zephyr -d build-mcuboot
-          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb west build -b lexxpluss_mb02 lexxpluss_apps
+          make IN_HOST=1 setup
+          make IN_HOST=1 bootloader
+          make IN_HOST=1 firmware
       - name: Notification
         uses: act10ns/slack@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/zephyr-build:v0.21.0
+      options: --user root
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -44,6 +45,7 @@ jobs:
       - name: build
         id: build
         run: |
+          set -e
           make IN_HOST=1 firmware_initial
           make IN_HOST=1 clean
           make IN_HOST=1 firmware_tug_initial

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,25 +31,22 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: zephyrprojectrtos/zephyr-build:v0.21.0
-      options: --user root
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: setup
+        id: setup
+        run: |
+          set -e
+          make IN_HOST=1 setup
       - name: build
         id: build
         run: |
-          set -e
-          west init -l lexxpluss_apps
-          west update
-          west config --global zephyr.base-prefer configfile
-          west zephyr-export
-          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb west build -b lexxpluss_mb02 bootloader/mcuboot/boot/zephyr -d build-mcuboot
-          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb west build -b lexxpluss_mb02 lexxpluss_apps
-          dd if=/dev/zero bs=1k count=256 | tr "\000" "\377" > bl_with_ff.bin
-          dd if=build-mcuboot/zephyr/zephyr.bin of=bl_with_ff.bin conv=notrunc
-          cat bl_with_ff.bin build/zephyr/zephyr.signed.bin > firmware.bin
+          make IN_HOST=1 firmware_initial
+          make IN_HOST=1 clean
+          make IN_HOST=1 firmware_tug_initial
       - name: release
         id: create_release
         uses: actions/create-release@v1
@@ -67,7 +64,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./firmware.bin
+          asset_path: ./out/firmware.bin
           asset_name: LexxHard-MainBoard-Firmware-Initial-${{ github.ref_name }}.bin
           asset_content_type: application/octet-stream
       - name: upload update firmware
@@ -77,8 +74,28 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/zephyr/zephyr.signed.confirmed.bin
+          asset_path: ./out/zephyr.signed.confirmed.bin
           asset_name: LexxHard-MainBoard-Firmware-Update-${{ github.ref_name }}.bin
+          asset_content_type: application/octet-stream
+      - name: upload initial firmware_tug
+        id: upload-release-asset-firmware-tug
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./out/firmware_tug.bin
+          asset_name: LexxHard-MainBoard-Firmware-Tug-Initial-${{ github.ref_name }}.bin
+          asset_content_type: application/octet-stream
+      - name: upload update firmware_tug
+        id: upload-release-asset-updator-tug
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./out/zephyr_tug.signed.confirmed.bin
+          asset_name: LexxHard-MainBoard-Firmware-Tug-Update-${{ github.ref_name }}.bin
           asset_content_type: application/octet-stream
       - name: Notification
         uses: act10ns/slack@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,18 +37,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: setup
-        id: setup
-        run: |
-          set -e
-          make IN_HOST=1 setup
       - name: build
         id: build
         run: |
           set -e
-          make IN_HOST=1 firmware_initial
-          make IN_HOST=1 clean
-          make IN_HOST=1 firmware_tug_initial
+          cp -a /home/user/.cmake $HOME
+          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb make IN_HOST=1 setup
+          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb make IN_HOST=1 firmware_initial
+          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb make IN_HOST=1 clean
+          ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb make IN_HOST=1 firmware_tug_initial
       - name: release
         id: create_release
         uses: actions/create-release@v1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,111 @@
+# Copyright (c) 2024, LexxPluss Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+VERSION:=$(shell git describe --tags HEAD)
+RUNNER:=$(if $(IN_HOST), $(), docker compose run --rm zephyrbuilder)
+
+.PHONY: all
+all: bootloader firmware_initial
+
+.PHONY: clean
+clean:
+	rm -rf build-mcuboot build
+
+.PHONY: distclean
+distclean: clean
+	rm -rf build-mcuboot build bootloader modules ros_msgs tools zephyr out .west
+
+.PHONY: build
+build: docker-compose.yml Dockerfile
+	docker compose build
+
+.PHONY: setup
+setup:
+	$(RUNNER) west init -l lexxpluss_apps
+	$(RUNNER) west update
+	$(RUNNER) west config --global zephyr.base-prefer configfile
+	mkdir -p out
+
+.PHONY: update
+update:
+	$(RUNNER) west update
+
+out/zephyr.bin:
+	$(RUNNER) bash -c "west zephyr-export && west build -b lexxpluss_mb02 bootloader/mcuboot/boot/zephyr -d build-mcuboot"
+	mv build-mcuboot/zephyr/zephyr.bin out/zephyr.bin
+
+out/zephyr.signed.bin out/zephyr.signed.confirmed.bin:
+	$(RUNNER) bash -c "west zephyr-export && west build -b lexxpluss_mb02 lexxpluss_apps -- -DVERSION=$(VERSION)"
+	mv build/zephyr/zephyr.signed.bin out/zephyr.signed.bin
+	mv build/zephyr/zephyr.signed.confirmed.bin out/zephyr.signed.confirmed.bin
+
+out/zephyr_tug.signed.bin out/zephyr_tug.signed.confirmed.bin:
+	$(RUNNER) bash -c "west zephyr-export && west build -b lexxpluss_mb02 lexxpluss_apps -- -DVERSION=$(VERSION) -DENABLE_TUG=1"
+	mv build/zephyr/zephyr.signed.bin out/zephyr_tug.signed.bin
+	mv build/zephyr/zephyr.signed.confirmed.bin out/zephyr_tug.signed.confirmed.bin
+
+out/zephyr_interlock.signed.bin out/zephyr_interlock.signed.confirmed.bin:
+	$(RUNNER) bash -c "west zephyr-export && west build -b lexxpluss_mb02 lexxpluss_apps -- -DVERSION=$(VERSION) -DENABLE_TUG=1"
+	mv build/zephyr/zephyr.signed.bin out/zephyr_interlock.signed.bin
+	mv build/zephyr/zephyr.signed.confirmed.bin out/zephyr_interlock.signed.confirmed.bin
+
+out/bl_with_ff.bin: out/zephyr.bin
+	dd if=/dev/zero bs=1k count=256 | tr "\000" "\377" > out/bl_with_ff.bin
+	dd if=out/zephyr.bin of=out/bl_with_ff.bin conv=notrunc
+
+out/firmware.bin: out/bl_with_ff.bin out/zephyr.signed.bin
+	cat out/bl_with_ff.bin out/zephyr.signed.bin > out/firmware.bin
+
+out/firmware_tug.bin: out/bl_with_ff.bin out/zephyr_tug.signed.bin
+	cat out/bl_with_ff.bin out/zephyr_tug.signed.bin > out/firmware_tug.bin
+
+out/firmware_interlock.bin: out/bl_with_ff.bin out/zephyr_interlock.signed.bin
+	cat out/bl_with_ff.bin out/zephyr_interlock.signed.bin > out/firmware_interlock.bin
+
+.PHONY: bootloader
+bootloader: out/zephyr.bin
+	@
+
+.PHONY: firmware
+firmware: out/zephyr.signed.bin out/zephyr.signed.confirmed.bin
+	@
+
+.PHONY: firmware_tug
+firmware_tug: out/zephyr_tug.signed.bin  out/zephyr_tug.signed.confirmed.bin
+	@
+
+.PHONY: firmware_interlock
+firmware_interlock: out/zephyr_interlock.signed.bin  out/zephyr_interlock.signed.confirmed.bin
+	@
+
+.PHONY: firmware_initial
+firmware_initial: out/firmware.bin
+	@
+
+.PHONY: firmware_tug_initial
+firmware_tug_initial: out/firmware_tug.bin
+	@
+
+.PHONY: firmware_interlock_initial
+firmware_interlock_initial: out/firmware_interlock.bin
+	@

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,13 @@ VERSION:=$(shell git describe --tags HEAD)
 RUNNER:=$(if $(IN_HOST), $(), docker compose run --rm zephyrbuilder)
 
 .PHONY: all
-all: firmware_initial firmware_tug_initial firmware_interlock_initial
+all: 
+	$(MAKE) clean
+	$(MAKE) firmware_initial
+	$(MAKE) clean
+	$(MAKE) firmware_tug_initial
+	$(MAKE) clean
+	$(MAKE) firmware_interlock_initial
 
 .PHONY: clean
 clean:
@@ -69,7 +75,7 @@ firmware_tug:
 
 .PHONY: firmware_interlock
 firmware_interlock:
-	$(RUNNER) bash -c "west zephyr-export && west build -b lexxpluss_mb02 lexxpluss_apps -- -DVERSION=$(VERSION) -DENABLE_TUG=1"
+	$(RUNNER) bash -c "west zephyr-export && west build -b lexxpluss_mb02 lexxpluss_apps -- -DVERSION=$(VERSION) -DENABLE_INTERLOCK=1"
 	mv build/zephyr/zephyr.signed.bin out/zephyr_interlock.signed.bin
 	mv build/zephyr/zephyr.signed.confirmed.bin out/zephyr_interlock.signed.confirmed.bin
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, LexxPluss Inc.
+# Copyright (c) 2024, LexxPluss Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -21,26 +21,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-/.idea/
-/.west/
-/bootloader/
-/build/
-/build-mcuboot/
-/modules/
-/ros_msgs/
-/tools/
-/zephyr/
-/compile_commands.json
-/out
-._.vscode
-._.west
-._bootloader
-._build
-._modules
-._ros_msgs
-._tools
-._zephyr
-docker_start.sh
-start.sh
-.vscode/._settings.json
-.vscode/settings.json
+version: '3'
+services:
+  zephyrbuilder:
+    image: zephyrprojectrtos/zephyr-build:v0.21.0
+    volumes:
+      - .:/workdir
+    environment:
+      ZEPHYR_TOOLCHAIN_VARIANT: "gnuarmemb"

--- a/lexxpluss_apps/CMakeLists.txt
+++ b/lexxpluss_apps/CMakeLists.txt
@@ -34,3 +34,11 @@ target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ros_msgs)
 if(ENABLE_INTERLOCK)
     add_definitions(-DENABLE_INTERLOCK)
 endif()
+
+if(ENABLE_TUG)
+    add_definitions(-DENABLE_TUG)
+endif()
+
+if(VERSION)
+    add_definitions(-DVERSION=${VERSION})
+endif()

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -142,15 +142,15 @@ public:
         switch (pos) {
         case POS::LEFT:
             result = enc.init(TIM3);
-            mm_per_pulse = 50.0f / 1054.0f;
-            break;
-        case POS::CENTER:
-            result = enc.init(TIM4);
 #ifdef ENABLE_TUG
             mm_per_pulse = 0.0033;
 #else
             mm_per_pulse = 50.0f / 1054.0f;
 #endif  // ENABLE_TUG
+            break;
+        case POS::CENTER:
+            result = enc.init(TIM4);
+            mm_per_pulse = 50.0f / 1054.0f;
             break;
         case POS::RIGHT:
             result = enc.init(TIM1);

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -146,11 +146,19 @@ public:
             break;
         case POS::CENTER:
             result = enc.init(TIM4);
+#ifdef ENABLE_TUG
+            mm_per_pulse = 0.0033;
+#else
             mm_per_pulse = 50.0f / 1054.0f;
+#endif  // ENABLE_TUG
             break;
         case POS::RIGHT:
             result = enc.init(TIM1);
+#ifdef ENABLE_TUG
+            mm_per_pulse = 0.0033;
+#else
             mm_per_pulse = 50.0f / 1054.0f;
+#endif  // ENABLE_TUG
             break;
         }
         reset_pulse();

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -42,12 +42,13 @@
 #  define VERSION v2.0.0-dev  // This version must not be used for production. Only for local build.
 #endif  // VERSION
 
-#ifdef ENABLE_TUG
+#if defined(ENABLE_TUG)
 #  define VERSION_STR STR(VERSION) "-tug"
+#elif defined(ENABLE_INTERLOCK)
+#  define VERSION_STR STR(VERSION) "-interlock"
 #else
 #  define VERSION_STR STR(VERSION)
-#endif  // ENABLE_TUG
-
+#endif  // ENABLE_TUG or ENABLE_INTERLOCK
 
 namespace lexxhard::can_controller {
 

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -34,6 +34,21 @@
 #include "misc_controller.hpp"
 #include "can_controller.hpp"
 
+
+#define QUOTE(name) #name
+#define STR(macro) QUOTE(macro)
+
+#ifndef VERSION
+#  define VERSION v2.0.0-dev  // This version must not be used for production. Only for local build.
+#endif  // VERSION
+
+#ifdef ENABLE_TUG
+#  define VERSION_STR STR(VERSION) "-tug"
+#else
+#  define VERSION_STR STR(VERSION)
+#endif  // ENABLE_TUG
+
+
 namespace lexxhard::can_controller {
 
 LOG_MODULE_REGISTER(can);
@@ -380,7 +395,7 @@ private:
 
     // Version Definition
     // [Hardware Change].[function added or interface change].[bug fix, reset to 0 when the compatibility is lost]
-    static constexpr char version[]{"2.10.1"};
+    static constexpr char version[]{VERSION_STR};
 } impl;
 
 int bmu_info(const shell *shell, size_t argc, char **argv)


### PR DESCRIPTION
ref: [HWDEV-2202)](https://lexxpluss.atlassian.net/browse/HWDEV-2202)

This PR is motivated to add tug edition of firmware and improve build environment. This PR contains following modifications.

* Add a Makefile to build firmware easily.
* Use tag  or commit hash  as version.
* Add a tug edition which contains followings
  * its VERSION has a suffix which is '-tug'
  * left and right acutator `mm_per_pulse` value are changed


Tug edition firmware which is a result of this PR is tested in robot as followings.

actuator controlled with specifying location which is 25[mm]
![IMG_0284](https://github.com/user-attachments/assets/1857fa48-fa50-4ad4-bc95-473e28c7ac7f)

actuator controlled with specifying location which is 35[mm]
![IMG_0285](https://github.com/user-attachments/assets/7f1f5f20-2537-4576-91b0-a0f7b1d81927)

actuator controlled with specifying location which is 45[mm]
![IMG_0289](https://github.com/user-attachments/assets/6367ff6c-f47f-4259-b71a-edb9be065fc5)