### PR TITLE
Amrsw 1126 dcrease led brightness

### DIFF
--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -361,7 +361,7 @@ private:
     const device *dev[4]{nullptr, nullptr, nullptr, nullptr};
     led_rgb pixeldata[2][PIXELS], pixeldata_back[2][PIXELS_BACK];
     uint32_t counter{0};
-    static constexpr uint8_t clamp_threshold{0xc0};
+    static constexpr uint8_t clamp_threshold{0x80};
     static const led_rgb emergency_stop, amr_mode, agv_mode, mission_pause, path_blocked, manual_drive;
     static const led_rgb dock_mode, waiting_for_job, orange, sequence, move_actuator, lockdown, black;
 } impl;

--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -361,7 +361,7 @@ private:
     const device *dev[4]{nullptr, nullptr, nullptr, nullptr};
     led_rgb pixeldata[2][PIXELS], pixeldata_back[2][PIXELS_BACK];
     uint32_t counter{0};
-    uint8_t clamp_threshold{0xff};
+    static constexpr uint8_t clamp_threshold{0xc0};
     static const led_rgb emergency_stop, amr_mode, agv_mode, mission_pause, path_blocked, manual_drive;
     static const led_rgb dock_mode, waiting_for_job, orange, sequence, move_actuator, lockdown, black;
 } impl;


### PR DESCRIPTION
ref: [AMRSW-1126](https://lexxpluss.atlassian.net/browse/AMRSW-1126)

This PR is motivated to decrease led brightness to suppress supplying current of LED. This features are already released as the patched version of v2.6.1 from [this branch](HWDEV-2407-make-led-blightness-attenable-from-v2.6.1). This PR is the port of this feature from it.

In this PR, when max channel intensity or average channel intensity is greater equal than 0x80, all channel intensities are clamped to meet former condition.

this PR is evaluated in real robot.

[AMRSW-1126]: https://lexxpluss.atlassian.net/browse/AMRSW-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ