### PR TITLE
AMRSW-1283 enable lockdown manually

### DIFF
--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -187,6 +187,7 @@ public:
     }
     void brd_emgoff() {
         ros2board.emergency_stop = false;
+        ros2board.lockdown = false;
         heartbeat_timeout = false;
     }
     void brd_info(const shell *shell) const {
@@ -369,6 +370,7 @@ private:
             if (i > 75.0f)
                 actuator_overheat = true;
         }
+        const bool should_lockdown = !get_emergency_switch() && (ros2board.lockdown || heartbeat_timeout);
         zcan_frame frame{
             .id{0x201},
             .rtr{CAN_DATAFRAME},
@@ -377,7 +379,7 @@ private:
             .data{
                 ros2board.emergency_stop,
                 ros2board.power_off,
-                !get_emergency_switch() && heartbeat_timeout,
+                should_lockdown,
                 main_overheat,
                 actuator_overheat,
                 ros2board.wheel_power_off

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -58,7 +58,7 @@ struct msg_board {
 } __attribute__((aligned(4)));
 
 struct msg_control {
-    bool emergency_stop, power_off, wheel_power_off;
+    bool emergency_stop, power_off, wheel_power_off, lockdown;
 } __attribute__((aligned(4)));
 
 void init();

--- a/lexxpluss_apps/src/rosserial_board.hpp
+++ b/lexxpluss_apps/src/rosserial_board.hpp
@@ -52,6 +52,7 @@ public:
         nh.advertise(pub_charge_voltage);
         nh.subscribe(sub_emergency);
         nh.subscribe(sub_poweroff);
+        nh.subscribe(sub_lockdown);
         nh.subscribe(sub_lexxhard);
         nh.subscribe(sub_messenger);
         msg_fan.data = msg_fan_data;
@@ -129,6 +130,11 @@ private:
         while (k_msgq_put(&can_controller::msgq_control, &ros2board, K_NO_WAIT) != 0)
             k_msgq_purge(&can_controller::msgq_control);
     }
+    void callback_lockdown(const std_msgs::Bool &req) {
+        ros2board.lockdown = req.data;
+        while (k_msgq_put(&can_controller::msgq_control, &ros2board, K_NO_WAIT) != 0)
+            k_msgq_purge(&can_controller::msgq_control);
+    }
     void callback_lexxhard(const std_msgs::String &req) {
         if (strncmp(req.data, "wheel_", 6) == 0)
             ros2board.wheel_power_off = strcmp(req.data, "wheel_poweroff") == 0;
@@ -162,6 +168,9 @@ private:
     };
     ros::Subscriber<std_msgs::Bool, ros_board> sub_poweroff{
         "/control/request_power_off", &ros_board::callback_poweroff, this
+    };
+    ros::Subscriber<std_msgs::Bool, ros_board> sub_lockdown{
+        "/control/request_lockdown", &ros_board::callback_lockdown, this
     };
     ros::Subscriber<std_msgs::String, ros_board> sub_lexxhard{
         "/lexxhard/setup", &ros_board::callback_lexxhard, this


### PR DESCRIPTION
ref: [AMRSW-1283](https://lexxpluss.atlassian.net/browse/AMRSW-1283)

This PR is motivated to add a subscriber for `/control/request_lockdown`. When this subscriber receives `true`, firmware turns into lockdown.

[AMRSW-1283]: https://lexxpluss.atlassian.net/browse/AMRSW-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ