### PR TITLE
[AMRSW: 1248]Update "emergency_stop" keyword to "safety_pause"

### DIFF
--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -126,7 +126,7 @@ private:
         switch (message.pattern) {
         default:
         case msg::NONE:            fill(black); break;
-        case msg::EMERGENCY_STOP:  fill_strobe(emergency_stop, 10, 50, 1000); break;
+        case msg::SAFETY_PAUSE:  fill_strobe(emergency_stop, 10, 50, 1000); break;
         case msg::AMR_MODE:        fill(amr_mode); break;
         case msg::AGV_MODE:        fill(agv_mode); break;
         case msg::MISSION_PAUSE:   fill(mission_pause); break;

--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -126,7 +126,7 @@ private:
         switch (message.pattern) {
         default:
         case msg::NONE:            fill(black); break;
-        case msg::SAFETY_PAUSE:  fill_strobe(emergency_stop, 10, 50, 1000); break;
+        case msg::SAFETY_PAUSE:  fill_strobe(safety_pause, 10, 50, 1000); break;
         case msg::AMR_MODE:        fill(amr_mode); break;
         case msg::AGV_MODE:        fill(agv_mode); break;
         case msg::MISSION_PAUSE:   fill(mission_pause); break;

--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -362,10 +362,10 @@ private:
     led_rgb pixeldata[2][PIXELS], pixeldata_back[2][PIXELS_BACK];
     uint32_t counter{0};
     static constexpr uint8_t clamp_threshold{0x80};
-    static const led_rgb emergency_stop, amr_mode, agv_mode, mission_pause, path_blocked, manual_drive;
+    static const led_rgb safety_pause, amr_mode, agv_mode, mission_pause, path_blocked, manual_drive;
     static const led_rgb dock_mode, waiting_for_job, orange, sequence, move_actuator, lockdown, black;
 } impl;
-const led_rgb led_controller_impl::emergency_stop {.r{0x80}, .g{0x00}, .b{0x00}};
+const led_rgb led_controller_impl::safety_pause {.r{0x80}, .g{0x00}, .b{0x00}};
 const led_rgb led_controller_impl::amr_mode       {.r{0x00}, .g{0x80}, .b{0x80}};
 const led_rgb led_controller_impl::agv_mode       {.r{0x45}, .g{0xff}, .b{0x00}};
 const led_rgb led_controller_impl::mission_pause  {.r{0xff}, .g{0xff}, .b{0x00}};

--- a/lexxpluss_apps/src/led_controller.hpp
+++ b/lexxpluss_apps/src/led_controller.hpp
@@ -96,7 +96,7 @@ struct msg {
     uint32_t pattern{NONE}, interrupt_ms{0}, cpm{0};
     uint8_t rgb[3]{0, 0, 0};
     static constexpr uint32_t NONE{0};
-    static constexpr uint32_t EMERGENCY_STOP{1};
+    static constexpr uint32_t SAFETY_PAUSE{1};
     static constexpr uint32_t AMR_MODE{2};
     static constexpr uint32_t AGV_MODE{3};
     static constexpr uint32_t MISSION_PAUSE{4};

--- a/lexxpluss_apps/src/led_controller.hpp
+++ b/lexxpluss_apps/src/led_controller.hpp
@@ -36,7 +36,7 @@ struct msg {
     msg(uint32_t pattern, uint32_t interrupt_ms) :
         pattern(pattern), interrupt_ms(interrupt_ms) {}
     msg(const char *str) {
-        if      (strcmp(str, "emergency_stop")  == 0) pattern = EMERGENCY_STOP;
+        if      (strcmp(str, "safety_pause")  == 0) pattern = EMERGENCY_STOP;
         else if (strcmp(str, "amr_mode")        == 0) pattern = AMR_MODE;
         else if (strcmp(str, "agv_mode")        == 0) pattern = AGV_MODE;
         else if (strcmp(str, "mission_pause")   == 0) pattern = MISSION_PAUSE;

--- a/lexxpluss_apps/src/led_controller.hpp
+++ b/lexxpluss_apps/src/led_controller.hpp
@@ -36,7 +36,7 @@ struct msg {
     msg(uint32_t pattern, uint32_t interrupt_ms) :
         pattern(pattern), interrupt_ms(interrupt_ms) {}
     msg(const char *str) {
-        if      (strcmp(str, "safety_pause")  == 0) pattern = EMERGENCY_STOP;
+        if      (strcmp(str, "safety_pause")  == 0) pattern = SAFETY_PAUSE;
         else if (strcmp(str, "amr_mode")        == 0) pattern = AMR_MODE;
         else if (strcmp(str, "agv_mode")        == 0) pattern = AGV_MODE;
         else if (strcmp(str, "mission_pause")   == 0) pattern = MISSION_PAUSE;


### PR DESCRIPTION
Replaced occurrences of "emergency_stop" with "safety_pause" in the sender_led and led_controller logic. This improves terminology consistency and better reflects the intended functionality.