### PR TITLE
feat/AMRSW-1815 add charging request handler

### DIFF
--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -199,6 +199,14 @@ public:
         ros2board.lockdown = false;
         heartbeat_timeout = false;
     }
+    void brd_acreqon() {
+        ros2board.auto_charge_request_enable = true;
+        heartbeat_timeout = false;
+    }
+    void brd_acreqoff() {
+        ros2board.auto_charge_request_enable = false;
+        heartbeat_timeout = false;
+    }
     void brd_info(const shell *shell) const {
         shell_print(shell,
                     "Bumper:%d/%d Emergency:%d/%d Power:%d\n"
@@ -466,14 +474,15 @@ private:
             .id{0x201},
             .rtr{CAN_DATAFRAME},
             .id_type{CAN_STANDARD_IDENTIFIER},
-            .dlc{6},
+            .dlc{7},
             .data{
                 ros2board.emergency_stop,
                 ros2board.power_off,
                 should_lockdown,
                 main_overheat,
                 actuator_overheat,
-                ros2board.wheel_power_off
+                ros2board.wheel_power_off,
+                ros2board.auto_charge_request_enable,
             }
         };
         can_send(dev, &frame, K_MSEC(100), nullptr, nullptr);
@@ -511,6 +520,18 @@ int brd_emgoff(const shell *shell, size_t argc, char **argv)
     return 0;
 }
 
+int brd_acreqon(const shell *shell, size_t argc, char **argv)
+{
+    impl.brd_acreqon();
+    return 0;
+}
+
+int brd_acreqoff(const shell *shell, size_t argc, char **argv)
+{
+    impl.brd_acreqoff();
+    return 0;
+}
+
 int brd_info(const shell *shell, size_t argc, char **argv)
 {
     impl.brd_info(shell);
@@ -519,6 +540,8 @@ int brd_info(const shell *shell, size_t argc, char **argv)
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_brd,
     SHELL_CMD(emgoff, NULL, "ROS emergency stop off", brd_emgoff),
+    SHELL_CMD(acreqon, NULL, "ROS auto charge request enable on", brd_acreqon),
+    SHELL_CMD(acreqoff, NULL, "ROS auto charge request enable off", brd_acreqoff),
     SHELL_CMD(info, NULL, "Board information", brd_info),
     SHELL_SUBCMD_SET_END
 );

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -58,7 +58,7 @@ struct msg_board {
 } __attribute__((aligned(4)));
 
 struct msg_control {
-    bool emergency_stop, power_off, wheel_power_off, lockdown;
+    bool emergency_stop, power_off, wheel_power_off, lockdown, auto_charge_request_enable;
 } __attribute__((aligned(4)));
 
 // msg_diagnostics only support can msg length failure for now

--- a/lexxpluss_apps/src/rosserial_board_service.hpp
+++ b/lexxpluss_apps/src/rosserial_board_service.hpp
@@ -23,44 +23,30 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "rosserial_hardware_zephyr.hpp"
-#include "rosserial_actuator_service.hpp"
-#include "rosserial_board_service.hpp"
-#include "rosserial_service.hpp"
+#pragma once
 
-namespace lexxhard::rosserial_service {
+#include <zephyr.h>
+#include "std_srvs/SetBool.h"
+#include "ros/node_handle.h"
+#include "rosserial_board_store.hpp"
 
-class {
+namespace lexxhard {
+
+class ros_board_service {
 public:
-    int init() {
-        nh.initNode(const_cast<char*>("UART_2"));
-        actuator_service.init(nh);
-        board_service.init(nh);
-        return 0;
-    }
-    void run() {
-        while (true) {
-            nh.spinOnce();
-            k_usleep(1);
-        }
+    void init(ros::NodeHandle &nh) {
+        nh.advertiseService(service_auto_charge_request_enable);
     }
 private:
-    ros::NodeHandle nh;
-    ros_actuator_service actuator_service;
-    ros_board_service board_service;
-} impl;
+    void callback_auto_charge_request_enable(const std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res) {
+        lexxhard::ros_board_store::set_auto_charge_request_enable(req.data);
+        // Don't put ros2board into queue here. It will be put as a part of heartbeat.
 
-void init()
-{
-    impl.init();
-}
-
-void run(void *p1, void *p2, void *p3)
-{
-    impl.run();
-}
-
-k_thread thread;
+        res.success = true;
+    }
+    ros::ServiceServer<std_srvs::SetBool::Request, std_srvs::SetBool::Response, ros_board_service>
+        service_auto_charge_request_enable{"/control/auto_charge_request/enable", &ros_board_service::callback_auto_charge_request_enable, this};
+};
 
 }
 

--- a/lexxpluss_apps/src/rosserial_board_store.cpp
+++ b/lexxpluss_apps/src/rosserial_board_store.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/atomic.h>
+#include "rosserial_board_store.hpp"
+
+namespace {
+class ros_board_store_impl {
+public:
+  void set_emergency_stop(bool v)   { ros2board.emergency_stop = v; }
+  void set_power_off(bool v)        { ros2board.power_off = v; }
+  void set_lockdown(bool v)         { ros2board.lockdown = v; }
+  void set_wheel_power_off(bool v)  { ros2board.wheel_power_off = v; }
+  void set_auto_charge_request_enable(bool v) {
+    atomic_set(&pending_auto_charge, v ? 1 : 0);
+  }
+  lexxhard::can_controller::msg_control get_ros2board() {
+    ros2board.auto_charge_request_enable = (atomic_get(&pending_auto_charge) != 0);
+    return ros2board;
+  }
+private:
+  atomic_t pending_auto_charge = ATOMIC_INIT(0);
+  lexxhard::can_controller::msg_control ros2board{0};
+} impl;
+} // namespace
+
+void lexxhard::ros_board_store::set_emergency_stop(bool data) {
+  impl.set_emergency_stop(data);
+}
+
+void lexxhard::ros_board_store::set_power_off(bool data) {
+  impl.set_power_off(data);
+}
+
+void lexxhard::ros_board_store::set_lockdown(bool data) {
+  impl.set_lockdown(data);
+}
+
+void lexxhard::ros_board_store::set_wheel_power_off(bool data) {
+  impl.set_wheel_power_off(data);
+}
+
+void lexxhard::ros_board_store::set_auto_charge_request_enable(bool data) {
+  impl.set_auto_charge_request_enable(data);
+}
+
+lexxhard::can_controller::msg_control lexxhard::ros_board_store::get_ros2board() {
+  return impl.get_ros2board();
+}

--- a/lexxpluss_apps/src/rosserial_board_store.hpp
+++ b/lexxpluss_apps/src/rosserial_board_store.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, LexxPluss Inc.
+ * Copyright (c) 2025, LexxPluss Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,45 +23,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "rosserial_hardware_zephyr.hpp"
-#include "rosserial_actuator_service.hpp"
-#include "rosserial_board_service.hpp"
-#include "rosserial_service.hpp"
+#pragma once
+#include "can_controller.hpp"
 
-namespace lexxhard::rosserial_service {
-
-class {
-public:
-    int init() {
-        nh.initNode(const_cast<char*>("UART_2"));
-        actuator_service.init(nh);
-        board_service.init(nh);
-        return 0;
-    }
-    void run() {
-        while (true) {
-            nh.spinOnce();
-            k_usleep(1);
-        }
-    }
-private:
-    ros::NodeHandle nh;
-    ros_actuator_service actuator_service;
-    ros_board_service board_service;
-} impl;
-
-void init()
-{
-    impl.init();
+namespace lexxhard::ros_board_store {
+void set_emergency_stop(bool data);
+void set_power_off(bool data);
+void set_lockdown(bool data);
+void set_wheel_power_off(bool data);
+void set_auto_charge_request_enable(bool data);
+lexxhard::can_controller::msg_control get_ros2board();
 }
-
-void run(void *p1, void *p2, void *p3)
-{
-    impl.run();
-}
-
-k_thread thread;
-
-}
-
-// vim: set expandtab shiftwidth=4:


### PR DESCRIPTION
## Close Ticket

AMRSW-1815

## Description

This PR is motivated to handle auto_charging_request_enable signal. This signal is used as a request to charger to enable charging or not.

* Add a service to handle auto_charging_request_enable signal
* Add a handler to assign disable to auto_charging_request_enable signal when release emergency switch
* Add a store whose name is `ros_board_store` to share ros2board message status between rosserial_board and rosserial_board_service

## Testing

AMR used: v63002

- [x] Assign charging task
  - [x] Auto charging communication established
  - [x] Charging start
- [x] Assign charging out task after charging task completed
  - [x] Wait until charging voltage stopped
  - [x] Leave from the front of charging station
- [x] Release emergency stop button
  - [x] auto charge request is enabled 

## Dependent PRs (if any)

https://github.com/LexxPluss/LexxAuto/pull/3962